### PR TITLE
Update Secure Software Factory link to officially published CNCF doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ Reports and summaries
 
 -   [State of the Software Supply Chain](https://www.sonatype.com/hubfs/Q3%202021-State%20of%20the%20Software%20Supply%20Chain-Report/SSSC-Report-2021_0913_PM_2.pdf?hsLang=en-us) (Sonatype)
 
--   [The Secure Software Factory](https://acrobat.adobe.com/link/review?uri=urn%3Aaaid%3Ascds%3AUS%3Ad35dcd5d-b284-381a-a948-0478460c7e4c#pageNum=6) (CNCF)
+-   [The Secure Software Factory](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf) (CNCF)
     -   [Software Supply Chain Security Best Practices](https://project.linuxfoundation.org/hubfs/CNCF_SSCP_v1.pdf) (CNCF): its predecessor


### PR DESCRIPTION
Now that the Secure Software Factory is officially published, it would be great to link to the TAG Security repo link.